### PR TITLE
Update new Buffer calls for NodeJS 6.0+ compatibility

### DIFF
--- a/service/javascript/assistants/CryptAssistant.js
+++ b/service/javascript/assistants/CryptAssistant.js
@@ -27,13 +27,13 @@ CryptAssistant.prototype.run = function (outerfuture) {
     future = KeyStore.getKeyDecryptedByName(appId, args.keyname);
 
     future.then(this, function keyCB() {
-        var result = future.result, algorithm, cipher, buffer, keydata, iv, resData = new Buffer("");
+        var result = future.result, algorithm, cipher, buffer, keydata, iv, resData = new Buffer.from("");
         if (result.returnValue === true) {
             if (args.algorithm !== result.type) {
                 outerfuture.exception = {errorCode: -1, message: "Stored key algorithm and parameter differ."};
             }
 
-            keydata = new Buffer(result.keydata, "base64");
+            keydata = new Buffer.from(result.keydata, "base64");
             debug("Keydata: ", keydata, " with length", keydata.length);
             algorithm = result.type + "-" + keydata.length * 8;
             if (args.mode !== "none") {
@@ -41,7 +41,7 @@ CryptAssistant.prototype.run = function (outerfuture) {
             }
             try {
                 if (args.iv) {
-                    iv = new Buffer(args.iv, "base64");
+                    iv = new Buffer.from(args.iv, "base64");
                     if (args.decrypt) {
                         debug(algorithm, " for decryption with iv.");
                         cipher = crypto.createDecipheriv(algorithm, keydata, iv);
@@ -77,7 +77,7 @@ CryptAssistant.prototype.run = function (outerfuture) {
                     };
                 });
 
-                buffer = new Buffer(args.data, "base64");
+                buffer = new Buffer.from(args.data, "base64");
                 debug("Writing " + buffer.length + " bytes of data.");
                 cipher.write(buffer);
                 cipher.end();

--- a/service/javascript/utils/KeyStore.js
+++ b/service/javascript/utils/KeyStore.js
@@ -17,7 +17,7 @@ var KeyStore = (function () {
     }
 
     function _crypt(decrypt, inData) {
-        var future = new Future(), cipher, data = new Buffer("");
+        var future = new Future(), cipher, data = new Buffer.from("");
         if (decrypt) {
             cipher = crypto.createDecipher("AES-256-CBC", masterkey);
         } else {
@@ -57,7 +57,7 @@ var KeyStore = (function () {
             props.forEach(function (name) {
                 if (!dest[name]) {
                     if (Buffer.isBuffer(from[name])) {
-                        dest[name] = new Buffer(from[name].length);
+                        dest[name] = new Buffer.from(from[name].length);
                         from[name].copy(dest[name]);
                     } else if (typeof from[name] === "object") {
                         dest[name] = KeyStore.copyKey({}, from[name]);
@@ -82,7 +82,7 @@ var KeyStore = (function () {
                 debug("Got key: ", key);
                 if (!Buffer.isBuffer(key.keydata)) {
                     debug("Have to create buffer from keydata.");
-                    key.keydata = new Buffer(key.keydata.data);
+                    key.keydata = new Buffer.from(key.keydata.data);
                 }
                 future.result = {
                     key: key,
@@ -105,7 +105,7 @@ var KeyStore = (function () {
                 if (result.returnValue === true) {
                     key = result.key;
                     if (key.nohide) {
-                        cData = new Buffer(key.keydata); //we store keydata as buffer array.
+                        cData = new Buffer.from(key.keydata); //we store keydata as buffer array.
                         debug("ciphered: ", cData.toString("utf-8"));
                         decrypt(cData).then(this, function decryptCB(f2) {
                             var r2 = f2.result;
@@ -155,9 +155,9 @@ var KeyStore = (function () {
             }
 
             if (key.type === "ASCIIBLOB") {
-                cData = new Buffer(key.keydata, "utf-8");
+                cData = new Buffer.from(key.keydata, "utf-8");
             } else {
-                cData = new Buffer(key.keydata, "base64");
+                cData = new Buffer.from(key.keydata, "base64");
             }
             future.nest(encrypt(cData));
 

--- a/service/javascript/utils/KeyStoreSQLite.js
+++ b/service/javascript/utils/KeyStoreSQLite.js
@@ -13,7 +13,7 @@ var KeyStore = (function () {
         stringToType = { AES: 1, DES: 2, "3DES": 3, HMACSHA1: 4, BLOB: 5, ASCIIBLOB: 6};
 
     function _crypt(decrypt, inData) {
-        var future = new Future(), cipher, data = new Buffer("");
+        var future = new Future(), cipher, data = new Buffer.from("");
         if (decrypt) {
             cipher = crypto.createDecipher("AES-256-CBC", masterkey);
         } else {
@@ -137,12 +137,12 @@ var KeyStore = (function () {
                     future.result = { returnValue: false, errorCode: -1, message: JSON.stringify(err) };
                 } else if (!row) {
                     if (key.type === "ASCIIBLOB") {
-                        cData = new Buffer(key.keydata, "utf-8");
+                        cData = new Buffer.from(key.keydata, "utf-8");
                         if (!key.size) {
                             key.size = key.keydata.length;
                         }
                     } else {
-                        cData = new Buffer(key.keydata, "base64");
+                        cData = new Buffer.from(key.keydata, "base64");
                         if (!key.size) {
                             key.size = cData.toString("base64").length;
                         }

--- a/test.js
+++ b/test.js
@@ -37,7 +37,7 @@ future.then(function () {
         type: "AES",
         size: 32,
         nohide: true,
-        keydata: new Buffer("1222345678901234567890123456789032").toString("base64")
+        keydata: new Buffer.from("1222345678901234567890123456789032").toString("base64")
     }));
 });
 
@@ -59,7 +59,7 @@ future.then(function () {
         type: "AES",
         size: 32,
         nohide: true,
-        keydata: new Buffer("1222345678901234567890123456789032").toString("base64")
+        keydata: new Buffer.from("1222345678901234567890123456789032").toString("base64")
     }));
 });
 


### PR DESCRIPTION
As per https://nodejs.org/api/buffer.html#buffer_new_buffer_string_encoding

Buffer.from should be used in our cases instead of Buffer.

This will solve the following warnings in the logs:
2019-05-08T16:13:07.899754Z [22] user.err keymanager [] legacy-log  (node:355) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>