### PR TITLE
KeyStore: Buffer(size) should become Buffer.alloc(size)

### DIFF
--- a/service/javascript/utils/KeyStore.js
+++ b/service/javascript/utils/KeyStore.js
@@ -57,7 +57,7 @@ var KeyStore = (function () {
             props.forEach(function (name) {
                 if (!dest[name]) {
                     if (Buffer.isBuffer(from[name])) {
-                        dest[name] = new Buffer.from(from[name].length);
+                        dest[name] = new Buffer.alloc(from[name].length);
                         from[name].copy(dest[name]);
                     } else if (typeof from[name] === "object") {
                         dest[name] = KeyStore.copyKey({}, from[name]);


### PR DESCRIPTION
Fixes a mistake in previous NodeJS upgrade.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>