### PR TITLE
keymanager: Add access to activitymanager

### DIFF
--- a/files/sysbus/com.palm.keymanager.perm.json
+++ b/files/sysbus/com.palm.keymanager.perm.json
@@ -1,5 +1,6 @@
 {
     "com.palm.keymanager": [
-        "services"
+        "services",
+        "activities.manage"
     ]
 }


### PR DESCRIPTION
Seems keymanager needs to be able to create activities as well.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>